### PR TITLE
typo: Exclude cd exercises step

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ OS: Tested on `Manjaro Linux x86_64`, support for other platforms is desired.
 git clone https://github.com/practicode-org/practice-cpp
 cd practice-cpp
 git submodule update --recursive --init
-cd exercises
 cmake -Bbuild .
 cmake --build build
 ```


### PR DESCRIPTION
After 53553db695e48d48343414a8b12ea640f76e2573,
there's no such directory anymore and the project can be built from its root